### PR TITLE
Small Fix: Negative Value Compare Without Double Cast

### DIFF
--- a/src/main/java/de/featjar/feature/model/analysis/visualization/AVisualizeFeatureModelStats.java
+++ b/src/main/java/de/featjar/feature/model/analysis/visualization/AVisualizeFeatureModelStats.java
@@ -239,7 +239,7 @@ public abstract class AVisualizeFeatureModelStats {
             }
 
             boolean anyNegativeValues =
-                    treeData.values().stream().map(value -> (Double) value).anyMatch(value -> value < 0);
+                    treeData.values().stream().map(value -> (Number) value).anyMatch(value -> value.doubleValue() < 0);
             if (anyNegativeValues) {
                 FeatJAR.log().error("Pie chart cannot be built with negative values");
                 continue;

--- a/src/test/java/de/featjar/feature/model/analysis/SimpleTreePropertiesTest.java
+++ b/src/test/java/de/featjar/feature/model/analysis/SimpleTreePropertiesTest.java
@@ -23,6 +23,7 @@ package de.featjar.feature.model.analysis;
 import static org.junit.jupiter.api.Assertions.*;
 
 import de.featjar.Common;
+import de.featjar.base.FeatJAR;
 import de.featjar.base.computation.Computations;
 import de.featjar.base.data.identifier.Identifiers;
 import de.featjar.feature.model.FeatureModel;


### PR DESCRIPTION
This is a small amendment. Pie Chart builder now checks for negative values without a Double cast that caused tests to fail. All tests work now.